### PR TITLE
Don't grow subscribers array indefinitely

### DIFF
--- a/src/useEntity.js
+++ b/src/useEntity.js
@@ -29,7 +29,9 @@ export const useEntity = (
     return () => {
       for (let i = 0, c = entity._subscribers.length; i < c; i++) {
         if (entity._subscribers[i] === subscriberFn) {
-          entity._subscribers[i] = null
+          // Move the last subscriber over the removed one and pop it 
+          entity._subscribers[i] = entity._subscribers[entity._subscribers.length - 1]
+          entity._subscribers.pop()
           break
         }
       }


### PR DESCRIPTION
When removing subscribers from an entity shrink the `_subscribers` array instead of just replacing the removed one with `null`.

For further optimization: When iterating over `_subscribers` there should not be any `null` items anymore so checks for that can be omitted if this fix is accepted.